### PR TITLE
Validate amount of adminaccounts in DB, to avoid creation of more than 6

### DIFF
--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -6,6 +6,10 @@ const Admin = require('../models/admin.model');
 module.exports = {
   async signup( req, res) {
     try {
+      const admins = await Admin.find();
+      if( admins.length > 5) {
+        throw new Error('Admins team is full')
+      }
       const { email, password } = req.body;
       if(password.length < 4 || password.length > 8) {
         throw new Error('Your password must be between 4 and 8 characters long');


### PR DESCRIPTION
# Validate amount of users with administrator privileges 

- In the signup method in the admins controller, a validation was added to block the creation of more admins, if 6 admin accounts are already stored in DB.
